### PR TITLE
Fixes the bias towards getting larger when resizing.

### DIFF
--- a/src/angular-gridster.js
+++ b/src/angular-gridster.js
@@ -1157,10 +1157,10 @@
 							oldSizeX = item.sizeX,
 							oldSizeY = item.sizeY,
 							hasCallback = gridster.resizable && gridster.resizable.resize;
-						item.row = gridster.pixelsToRows(elmY, false);
-						item.col = gridster.pixelsToColumns(elmX, false);
-						item.sizeX = gridster.pixelsToColumns(elmW, true);
-						item.sizeY = gridster.pixelsToRows(elmH, true);
+						item.row = gridster.pixelsToRows(elmY);
+						item.col = gridster.pixelsToColumns(elmX);
+						item.sizeX = gridster.pixelsToColumns(elmW);
+						item.sizeY = gridster.pixelsToRows(elmH);
 
 						if (
 							hasCallback || item.row !== oldRow || item.col !== oldCol || item.sizeX !== oldSizeX || item.sizeY !== oldSizeY


### PR DESCRIPTION
Passing 'true' to the pixelsToRows and pixelsToColumns functions causes
these functions to use Math.ceil to calculate how many rows or columns
the item should occupy. This biases towards getting larger and makes
resizing experience undesired. Similarly, 'false' to these functions
uses Math.floor. This isn't as important for us since we do not allow
resize handles on the left side of charts, but if we did the user would
have similarly poor experiences.

This also has the effect of fixing a bug when resizing off the grid.
Before, if you resized an item all the way to the right of the grid, the
item would move to the left and push other items down. Now, you cannot
resize past the edge of the grid.
