### PR TITLE
Controllers return themselves

### DIFF
--- a/src/angular-gridster.js
+++ b/src/angular-gridster.js
@@ -442,6 +442,7 @@
 				return Math.round(pixels / this.curColWidth);
 			};
 
+			return this;
 		}
 	])
 
@@ -781,6 +782,8 @@
 				this.$element.css('width', this.calculateElementWidth() + 'px');
 			}
 		};
+
+		return this;
 	})
 
 	.factory('GridsterDraggable', ['$document', '$timeout', '$window',


### PR DESCRIPTION
In the upgrade to Angular 1.4, we saw that controllers needed to explicitly return themselves if their internals were referenced elsewhere.

After upgrading, we saw JS errors coming from this library in production. Errors like `Cannot read property 'curColWidth' of null`. This change makes it so that the `GridsterCtrl` and `GridsterItemCtrl` controller functions return `this`. 


